### PR TITLE
Fix flag color tags reported by users

### DIFF
--- a/flaginfo.json
+++ b/flaginfo.json
@@ -380,7 +380,7 @@
     "wikipedialink": "https://en.wikipedia.org/wiki/Flag_of_Canada"
   },
   {
-    "tags": "cocos islands keeling islands green yellow star moon vegetation circle",
+    "tags": "cocos islands keeling islands green yellow brown star moon vegetation circle",
     "shortname": "cc",
     "name": "Cocos (Keeling) Islands",
     "proportion": "1:2",

--- a/flaginfo.json
+++ b/flaginfo.json
@@ -90,7 +90,7 @@
     "wikipedialink": "https://en.wikipedia.org/wiki/Flag_of_Antarctica"
   },
   {
-    "tags": "argentina blue white sun horizontal face",
+    "tags": "argentina blue white yellow sun horizontal face",
     "shortname": "ar",
     "name": "Argentina",
     "proportion": "5:8",
@@ -360,7 +360,7 @@
     "wikipedialink": "https://en.wikipedia.org/wiki/Flag_of_Belarus"
   },
   {
-    "tags": "belize white red white circle weapon tool horizontal text motto ribbon vegetation boat waves human face",
+    "tags": "belize blue red white green circle weapon tool horizontal text motto ribbon vegetation boat waves human face",
     "shortname": "bz",
     "name": "Belize",
     "proportion": "3:5",
@@ -2369,7 +2369,7 @@
     "wikipedialink": "https://en.wikipedia.org/wiki/Flag_of_the_United_States"
   },
   {
-    "tags": "uruguay white blue horizontal sun face",
+    "tags": "uruguay white blue yellow horizontal sun face",
     "shortname": "uy",
     "name": "Uruguay",
     "proportion": "2:3",
@@ -2509,7 +2509,7 @@
     "wikipedialink": "https://en.wikipedia.org/wiki/Flag_and_coat_of_arms_of_Mayotte"
   },
   {
-    "tags": "south africa red gren blue white yellow black triangle horizontal pan-african",
+    "tags": "south africa red green blue white yellow black triangle horizontal pan-african",
     "shortname": "za",
     "name": "South Africa",
     "proportion": "2:3",

--- a/i18n/ui/en.json
+++ b/i18n/ui/en.json
@@ -21,6 +21,7 @@
   "color_yellow": "Yellow",
   "color_white": "White",
   "color_black": "Black",
+  "color_brown": "Brown",
   "continent_africa": "Africa",
   "continent_asia": "Asia",
   "continent_europe": "Europe",

--- a/i18n/ui/en.json
+++ b/i18n/ui/en.json
@@ -22,6 +22,8 @@
   "color_white": "White",
   "color_black": "Black",
   "color_brown": "Brown",
+  "color_purple": "Purple",
+  "color_orange": "Orange",
   "continent_africa": "Africa",
   "continent_asia": "Asia",
   "continent_europe": "Europe",

--- a/i18n/ui/es.json
+++ b/i18n/ui/es.json
@@ -22,6 +22,8 @@
   "color_white": "Blanco",
   "color_black": "Negro",
   "color_brown": "Marrón",
+  "color_purple": "Morado",
+  "color_orange": "Naranja",
   "continent_africa": "África",
   "continent_asia": "Asia",
   "continent_europe": "Europa",

--- a/i18n/ui/es.json
+++ b/i18n/ui/es.json
@@ -21,6 +21,7 @@
   "color_yellow": "Amarillo",
   "color_white": "Blanco",
   "color_black": "Negro",
+  "color_brown": "Marrón",
   "continent_africa": "África",
   "continent_asia": "Asia",
   "continent_europe": "Europa",

--- a/index.html
+++ b/index.html
@@ -78,6 +78,7 @@
                         <button class="filter-btn" data-color="yellow">Yellow</button>
                         <button class="filter-btn" data-color="white">White</button>
                         <button class="filter-btn" data-color="black">Black</button>
+                        <button class="filter-btn" data-color="brown">Brown</button>
                     </div>
                 </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -79,6 +79,8 @@
                         <button class="filter-btn" data-color="white">White</button>
                         <button class="filter-btn" data-color="black">Black</button>
                         <button class="filter-btn" data-color="brown">Brown</button>
+                        <button class="filter-btn" data-color="purple">Purple</button>
+                        <button class="filter-btn" data-color="orange">Orange</button>
                     </div>
                 </div>
             </div>

--- a/script.js
+++ b/script.js
@@ -531,7 +531,7 @@ function rebuildFlags() {
         const code = info.shortname;
         const url = `https://flagcdn.com/w320/${code}.png`;
         const tags = info.tags || '';
-        const colorTags = ['red', 'blue', 'green', 'yellow', 'white', 'black'];
+        const colorTags = ['red', 'blue', 'green', 'yellow', 'white', 'black', 'brown'];
         const colors = colorTags.filter(color => tags.includes(color));
 
         return {

--- a/script.js
+++ b/script.js
@@ -531,7 +531,7 @@ function rebuildFlags() {
         const code = info.shortname;
         const url = `https://flagcdn.com/w320/${code}.png`;
         const tags = info.tags || '';
-        const colorTags = ['red', 'blue', 'green', 'yellow', 'white', 'black', 'brown'];
+        const colorTags = ['red', 'blue', 'green', 'yellow', 'white', 'black', 'brown', 'purple', 'orange'];
         const colors = colorTags.filter(color => tags.includes(color));
 
         return {

--- a/styles.css
+++ b/styles.css
@@ -597,6 +597,14 @@ h1 {
     background-color: #8b5a2b;
 }
 
+.color-filters .filter-btn[data-color="purple"]::before {
+    background-color: #9b59b6;
+}
+
+.color-filters .filter-btn[data-color="orange"]::before {
+    background-color: #e67e22;
+}
+
 /* Media query for mobile devices */
 @media (max-width: 768px) {
     header {

--- a/styles.css
+++ b/styles.css
@@ -593,6 +593,10 @@ h1 {
     background-color: #2c3e50;
 }
 
+.color-filters .filter-btn[data-color="brown"]::before {
+    background-color: #8b5a2b;
+}
+
 /* Media query for mobile devices */
 @media (max-width: 768px) {
     header {


### PR DESCRIPTION
Fixes color tags in `flaginfo.json`, which feed the in-app color list/filter, and adds **brown**, **purple** and **orange** as filterable colors.

### Color tag fixes
- **Argentina (#69):** add `yellow` (Sun of May)
- **Uruguay (#71):** add `yellow` (Sun of May)
- **Belize (#70):** add `blue` (field) and `green` (coat of arms), and remove a duplicate `white` in the tag list
- **South Africa (bonus):** fix `gren` typo → `green`

### New filterable colors
Several real flag colors were stored in tags but never surfaced in the modal color list or filter, because only red/blue/green/yellow/white/black were recognized. Promote three more:

- **brown (#66):** Cocos (Keeling) Islands palm tree; also surfaces Saint Helena (`sh`), which was already tagged brown. Cocos newly tagged `brown`.
- **purple (#67):** Dominica's Sisserou parrot (already tagged, now shown). Matches 2 flags.
- **orange:** India's saffron stripe and 10 others (Ireland, Côte d'Ivoire, Niger, …) — already tagged, now shown. Matches 11 flags.

Each new color adds: an entry in `colorTags` (script.js), a filter button (index.html), a swatch (styles.css), and `color_*` labels (i18n/ui/en.json, es.json).

Color tags are not localized, so no flag-level i18n changes are required. `scripts/validate-flags-i18n.sh` still passes.

Closes #66, #67, #69, #70, #71