### PR TITLE
Ignore .claude/settings.local.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ package-lock.json
 dist
 playwright-report
 test-results
+.claude/settings.local.json


### PR DESCRIPTION
Adds `.claude/settings.local.json` to `.gitignore`.

That file holds personal, per-developer Claude Code permission overrides (a local allowlist to reduce permission prompts) and should not be shared via the repo. Ignoring it keeps each developer's local settings out of version control while still letting the team agree on a committed `.claude/settings.json` later if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)