### PR TITLE
Add e2e coverage for the modal Colors line

### DIFF
--- a/tests/e2e/app.spec.js
+++ b/tests/e2e/app.spec.js
@@ -167,6 +167,20 @@ test.describe('Flagfilter UI flows', () => {
     await expect(page.locator('#flagModalTitle')).toHaveCount(0);
   });
 
+  test('modal Colors line reflects the flag color tags', async ({ page }) => {
+    // Argentina gained "yellow" (Sun of May) when the reported color tags were fixed.
+    await openFlagModalBySearch(page, 'argentina');
+    const argentinaColors = page.locator('.flag-info-details p', { hasText: 'Colors:' });
+    await expect(argentinaColors).toContainText('yellow');
+  });
+
+  test('modal Colors line surfaces brown for the Cocos Islands', async ({ page }) => {
+    // "brown" was promoted to a recognized color so the Cocos palm tree shows up.
+    await openFlagModalBySearch(page, 'cocos');
+    const cocosColors = page.locator('.flag-info-details p', { hasText: 'Colors:' });
+    await expect(cocosColors).toContainText('brown');
+  });
+
   test('English modal content renders inline flag links', async ({ page }) => {
     await openFlagModalBySearch(page, 'sweden');
 


### PR DESCRIPTION
## What
Adds two Playwright tests asserting the flag modal's `Colors:` line, which is rendered from each flag's recognized color tags (`flag.colors`).

- Argentina's modal lists **yellow** (the Sun of May tag added in #99)
- Cocos Islands' modal lists **brown** (the color promoted to filterable in #99)

## Why
The recent color-tag work (#66, #69, #70, #71) had no regression guard — there were modal tests for opening/closing and inline links, but none checked the displayed color list. These lock in that behavior.

## Notes
- Reuses the existing `openFlagModalBySearch` helper; no new infrastructure.
- I could not run the suite locally (no `node` on PATH in my environment), so this relies on the existing UI Tests workflow to verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)