### PR TITLE
Localize flag image alt text

### DIFF
--- a/i18n/ui/en.json
+++ b/i18n/ui/en.json
@@ -79,6 +79,7 @@
   "close": "Close",
   "no_results": "No flags match your search criteria.",
   "learn_more": "Learn more",
+  "flag_image_alt": "Flag of {name}",
   "flag_counter_one": "Showing {count} flag",
   "flag_counter_other": "Showing {count} flags",
   "no_information_available": "No information available.",

--- a/i18n/ui/es.json
+++ b/i18n/ui/es.json
@@ -79,6 +79,7 @@
   "close": "Cerrar",
   "no_results": "Ninguna bandera coincide con tu búsqueda.",
   "learn_more": "Saber más",
+  "flag_image_alt": "Bandera de {name}",
   "flag_counter_one": "Mostrando {count} bandera",
   "flag_counter_other": "Mostrando {count} banderas",
   "no_information_available": "No hay información disponible.",

--- a/script.js
+++ b/script.js
@@ -680,7 +680,7 @@ function renderFlagGrid() {
         flagCard.className = 'flag-card';
         
         flagCard.innerHTML = `
-            <img src="${flag.url}" alt="${flag.name} flag" loading="lazy">
+            <img src="${flag.url}" alt="${t('flag_image_alt', { name: flag.name })}" loading="lazy">
             <h3>${flag.name}</h3>
             <button class="learn-more-btn" data-code="${flag.code}" aria-haspopup="dialog">${t('learn_more')}</button>
         `;
@@ -809,7 +809,7 @@ function showFlagInfoModal(flag) {
     // Create flag image
     const flagImage = document.createElement('img');
     flagImage.src = flag.url;
-    flagImage.alt = `${flag.name} flag`;
+    flagImage.alt = t('flag_image_alt', { name: flag.name });
     flagImage.className = 'modal-flag-image';
     
     // Create flag information

--- a/tests/e2e/app.spec.js
+++ b/tests/e2e/app.spec.js
@@ -121,6 +121,18 @@ test.describe('Flagfilter UI flows', () => {
     await expect(page.locator('.learn-more-btn').first()).toHaveText('Saber más');
   });
 
+  test('flag image alt text is localized', async ({ page }) => {
+    const searchInput = page.locator('#searchInput');
+    const flagImage = page.locator('.flag-card img');
+
+    await searchInput.fill('sweden');
+    await expect(page.locator('.flag-card')).toHaveCount(1);
+    await expect(flagImage).toHaveAttribute('alt', 'Flag of Sweden');
+
+    await page.locator('#languageSelect').selectOption('es');
+    await expect(flagImage).toHaveAttribute('alt', 'Bandera de Suecia');
+  });
+
   test('English q search still works when the page is opened in Spanish', async ({ page }) => {
     await gotoApp(page, 'es', 'sweden');
 


### PR DESCRIPTION
## Summary

The grid and modal flag images used a hardcoded English alt string (`${name} flag`), which rendered as mixed-language text like **"Suecia flag"** when the UI was switched to Spanish.

This adds a localized `flag_image_alt` UI key and builds the alt text through `t()`:

- `en`: `Flag of {name}` → "Flag of Sweden"
- `es`: `Bandera de {name}` → "Bandera de Suecia"

Both the flag grid ([script.js](../blob/fix-image-alt-i18n/script.js)) and the detail modal now use it, so screen-reader text follows the selected language and reads more naturally.

Addresses the Lighthouse "image alt" follow-up.

## Tests

Adds a Playwright assertion that the grid image `alt` is `Flag of Sweden` in English and `Bandera de Suecia` after switching to Spanish.

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)
