### PR TITLE
Reserve flag image dimensions to prevent layout shift

### DIFF
--- a/script.js
+++ b/script.js
@@ -665,6 +665,32 @@ async function switchLanguage(language) {
     }
 }
 
+// flagcdn serves every w320 image at 320px wide; the height follows the flag's proportion.
+const FLAG_IMAGE_SOURCE_WIDTH = 320;
+// The grid crops every flag to a uniform 3:2 box (see `.flag-card img` in styles.css),
+// so reserve that ratio up front to avoid layout shift while images load.
+const FLAG_GRID_IMAGE_HEIGHT = Math.round(FLAG_IMAGE_SOURCE_WIDTH * 2 / 3);
+
+// Derive intrinsic pixel dimensions from a "height:width" proportion (e.g. "5:8").
+// Returns null for non-numeric proportions such as Nepal's "It's complicated.".
+function getFlagImageDimensions(proportion) {
+    const match = /^\s*(\d+)\s*:\s*(\d+)\s*$/.exec(String(proportion || ''));
+    if (!match) {
+        return null;
+    }
+
+    const heightUnits = Number(match[1]);
+    const widthUnits = Number(match[2]);
+    if (!heightUnits || !widthUnits) {
+        return null;
+    }
+
+    return {
+        width: FLAG_IMAGE_SOURCE_WIDTH,
+        height: Math.round(FLAG_IMAGE_SOURCE_WIDTH * heightUnits / widthUnits)
+    };
+}
+
 // Render flag grid
 function renderFlagGrid() {
     flagGrid.innerHTML = '';
@@ -680,7 +706,7 @@ function renderFlagGrid() {
         flagCard.className = 'flag-card';
         
         flagCard.innerHTML = `
-            <img src="${flag.url}" alt="${t('flag_image_alt', { name: flag.name })}" loading="lazy">
+            <img src="${flag.url}" alt="${t('flag_image_alt', { name: flag.name })}" width="${FLAG_IMAGE_SOURCE_WIDTH}" height="${FLAG_GRID_IMAGE_HEIGHT}" loading="lazy">
             <h3>${flag.name}</h3>
             <button class="learn-more-btn" data-code="${flag.code}" aria-haspopup="dialog">${t('learn_more')}</button>
         `;
@@ -811,7 +837,14 @@ function showFlagInfoModal(flag) {
     flagImage.src = flag.url;
     flagImage.alt = t('flag_image_alt', { name: flag.name });
     flagImage.className = 'modal-flag-image';
-    
+
+    // Reserve the flag's intrinsic dimensions so the modal does not shift while it loads.
+    const flagImageDimensions = getFlagImageDimensions(flag.info.proportion);
+    if (flagImageDimensions) {
+        flagImage.width = flagImageDimensions.width;
+        flagImage.height = flagImageDimensions.height;
+    }
+
     // Create flag information
     const flagInfo = document.createElement('div');
     flagInfo.className = 'flag-info-details';

--- a/tests/e2e/app.spec.js
+++ b/tests/e2e/app.spec.js
@@ -179,6 +179,21 @@ test.describe('Flagfilter UI flows', () => {
     await expect(page.locator('#flagModalTitle')).toHaveCount(0);
   });
 
+  test('grid flag images declare explicit dimensions to avoid layout shift', async ({ page }) => {
+    const flagImage = page.locator('.flag-card img').first();
+    await expect(flagImage).toHaveAttribute('width', '320');
+    await expect(flagImage).toHaveAttribute('height', '213');
+  });
+
+  test('modal flag image dimensions follow the flag proportion', async ({ page }) => {
+    // Sweden is 5:8, so the 320px-wide flagcdn image is 200px tall.
+    await openFlagModalBySearch(page, 'sweden');
+
+    const modalImage = page.locator('.modal-flag-image');
+    await expect(modalImage).toHaveAttribute('width', '320');
+    await expect(modalImage).toHaveAttribute('height', '200');
+  });
+
   test('modal Colors line reflects the flag color tags', async ({ page }) => {
     // Argentina gained "yellow" (Sun of May) when the reported color tags were fixed.
     await openFlagModalBySearch(page, 'argentina');


### PR DESCRIPTION
## Summary

Flag images had no intrinsic dimensions, so Lighthouse flagged them under [images without dimensions](https://web.dev/optimize-cls/#images-without-dimensions). This reserves space up front to avoid Cumulative Layout Shift.

- **Grid images** get explicit `width="320" height="213"` — the uniform 3:2 box the CSS already crops every flag to (`object-fit: cover` in `.flag-card img`), so there's no visual change, just reserved space.
- **Modal images** derive height from the flag's `proportion` field. flagcdn `w320` images are always 320px wide, so e.g. Sweden `5:8` → `320×200`. I verified the `H:W` direction against real flagcdn PNGs (se 320×200, ch 320×320, qa 320×126, us 320×168 — exact matches).
- Non-numeric proportions (Nepal's *"It's complicated."*, the golden-ratio flag) fall back to the existing CSS `height: auto`.

## Tests

Adds Playwright assertions that grid images carry `width`/`height` attributes and that the modal image dimensions follow the proportion (Sweden → 320×200).

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)
