### PR TITLE
Eagerly load and prioritize the first flag image (LCP)

### DIFF
--- a/script.js
+++ b/script.js
@@ -174,46 +174,49 @@ function syncQueryParamFromUiState() {
 
 function applyInitialQueryFromUrl() {
     const rawQuery = getQueryFromUrl();
-    if (!hasTextValue(rawQuery)) {
-        return;
-    }
 
-    const rawWords = rawQuery.trim().split(/\s+/).filter(Boolean);
-    const filterButtons = getFilterButtonsWithQueryMetadata();
-    const matchedButtons = new Set();
-    const remainingSearchTerms = [];
+    if (hasTextValue(rawQuery)) {
+        const rawWords = rawQuery.trim().split(/\s+/).filter(Boolean);
+        const filterButtons = getFilterButtonsWithQueryMetadata();
+        const matchedButtons = new Set();
+        const remainingSearchTerms = [];
 
-    for (let index = 0; index < rawWords.length;) {
-        let matchedEntry = null;
+        for (let index = 0; index < rawWords.length;) {
+            let matchedEntry = null;
 
-        for (let end = rawWords.length; end > index; end -= 1) {
-            const phrase = normalizeQueryValue(rawWords.slice(index, end).join(' '));
-            const entry = filterButtons.find((candidate) => (
-                !matchedButtons.has(candidate.button) && candidate.aliases.has(phrase)
-            ));
+            for (let end = rawWords.length; end > index; end -= 1) {
+                const phrase = normalizeQueryValue(rawWords.slice(index, end).join(' '));
+                const entry = filterButtons.find((candidate) => (
+                    !matchedButtons.has(candidate.button) && candidate.aliases.has(phrase)
+                ));
 
-            if (entry) {
-                matchedEntry = { entry, end };
-                break;
+                if (entry) {
+                    matchedEntry = { entry, end };
+                    break;
+                }
             }
+
+            if (matchedEntry) {
+                matchedButtons.add(matchedEntry.entry.button);
+                index = matchedEntry.end;
+                continue;
+            }
+
+            remainingSearchTerms.push(rawWords[index]);
+            index += 1;
         }
 
-        if (matchedEntry) {
-            matchedButtons.add(matchedEntry.entry.button);
-            index = matchedEntry.end;
-            continue;
-        }
+        matchedButtons.forEach((button) => {
+            button.classList.add('active');
+            updateToggleButtonState(button);
+        });
 
-        remainingSearchTerms.push(rawWords[index]);
-        index += 1;
+        searchInput.value = remainingSearchTerms.join(' ');
     }
 
-    matchedButtons.forEach((button) => {
-        button.classList.add('active');
-        updateToggleButtonState(button);
-    });
-
-    searchInput.value = remainingSearchTerms.join(' ');
+    // Render once, after the initial filter/search state is resolved, so the first
+    // paint (and the eager / high-priority LCP image) reflects the real above-the-fold
+    // flag instead of the unfiltered list. See PR #115.
     applyFilters();
 }
 
@@ -552,8 +555,10 @@ async function fetchFlags() {
         baseFlagInfo = await flagInfoResponse.json();
         rebuildFlags();
         
+        // Don't render here: initApp resolves the initial ?q= filter first, so the
+        // grid renders exactly once with the correct above-the-fold flags (and the
+        // eager / high-priority LCP image lands on the right one). See PR #115.
         filteredFlags = [...flags];
-        renderFlagGrid();
 
         return flags;
     } catch (error) {
@@ -1393,9 +1398,13 @@ async function initApp() {
     initDarkMode();
     const initialLanguage = getInitialLanguage();
     await switchLanguage(initialLanguage);
-    await fetchFlags();
+    const loadedFlags = await fetchFlags();
     initializeFilterSections();
-    applyInitialQueryFromUrl();
+    // Only render once the data loaded; on fetch failure fetchFlags returns
+    // undefined and leaves its own error message in the grid.
+    if (loadedFlags) {
+        applyInitialQueryFromUrl();
+    }
 }
 
 if (languageSelect) {

--- a/script.js
+++ b/script.js
@@ -670,6 +670,9 @@ const FLAG_IMAGE_SOURCE_WIDTH = 320;
 // The grid crops every flag to a uniform 3:2 box (see `.flag-card img` in styles.css),
 // so reserve that ratio up front to avoid layout shift while images load.
 const FLAG_GRID_IMAGE_HEIGHT = Math.round(FLAG_IMAGE_SOURCE_WIDTH * 2 / 3);
+// Eagerly load the first row(s) of above-the-fold flag images instead of lazily,
+// so the LCP image (the first one) is not deferred behind the data fetch. See #108.
+const EAGER_FLAG_IMAGE_COUNT = 8;
 
 // Derive intrinsic pixel dimensions from a "height:width" proportion (e.g. "5:8").
 // Returns null for non-numeric proportions such as Nepal's "It's complicated.".
@@ -701,16 +704,21 @@ function renderFlagGrid() {
         return;
     }
     
-    filteredFlags.forEach(flag => {
+    filteredFlags.forEach((flag, index) => {
         const flagCard = document.createElement('div');
         flagCard.className = 'flag-card';
-        
+
+        // Above-the-fold images load eagerly; the first one is the LCP candidate
+        // and gets high fetch priority. Everything below the fold stays lazy.
+        const loading = index < EAGER_FLAG_IMAGE_COUNT ? 'eager' : 'lazy';
+        const fetchPriority = index === 0 ? ' fetchpriority="high"' : '';
+
         flagCard.innerHTML = `
-            <img src="${flag.url}" alt="${t('flag_image_alt', { name: flag.name })}" width="${FLAG_IMAGE_SOURCE_WIDTH}" height="${FLAG_GRID_IMAGE_HEIGHT}" loading="lazy">
+            <img src="${flag.url}" alt="${t('flag_image_alt', { name: flag.name })}" width="${FLAG_IMAGE_SOURCE_WIDTH}" height="${FLAG_GRID_IMAGE_HEIGHT}" loading="${loading}"${fetchPriority}>
             <h3>${flag.name}</h3>
             <button class="learn-more-btn" data-code="${flag.code}" aria-haspopup="dialog">${t('learn_more')}</button>
         `;
-        
+
         flagGrid.appendChild(flagCard);
     });
     

--- a/tests/e2e/app.spec.js
+++ b/tests/e2e/app.spec.js
@@ -194,6 +194,17 @@ test.describe('Flagfilter UI flows', () => {
     await expect(modalImage).toHaveAttribute('height', '200');
   });
 
+  test('first flag image is eager and high priority for LCP, later ones stay lazy', async ({ page }) => {
+    const firstImage = page.locator('.flag-card img').first();
+    await expect(firstImage).toHaveAttribute('fetchpriority', 'high');
+    await expect(firstImage).toHaveAttribute('loading', 'eager');
+
+    // An image well past the above-the-fold batch is lazy and not prioritized.
+    const laterImage = page.locator('.flag-card img').nth(20);
+    await expect(laterImage).toHaveAttribute('loading', 'lazy');
+    await expect(laterImage).not.toHaveAttribute('fetchpriority', 'high');
+  });
+
   test('modal Colors line reflects the flag color tags', async ({ page }) => {
     // Argentina gained "yellow" (Sun of May) when the reported color tags were fixed.
     await openFlagModalBySearch(page, 'argentina');

--- a/tests/e2e/app.spec.js
+++ b/tests/e2e/app.spec.js
@@ -205,6 +205,18 @@ test.describe('Flagfilter UI flows', () => {
     await expect(laterImage).not.toHaveAttribute('fetchpriority', 'high');
   });
 
+  test('eager/high-priority image follows the initial ?q= filter, not the unfiltered list', async ({ page }) => {
+    // On a filtered landing the grid renders once already-filtered, so the
+    // prioritized LCP image is the filtered first flag (Sweden), not Andorra.
+    await gotoApp(page, 'en', 'blue sweden');
+    await expect(page.locator('.flag-card')).toHaveCount(1);
+
+    const firstImage = page.locator('.flag-card img').first();
+    await expect(firstImage).toHaveAttribute('alt', 'Flag of Sweden');
+    await expect(firstImage).toHaveAttribute('fetchpriority', 'high');
+    await expect(firstImage).toHaveAttribute('loading', 'eager');
+  });
+
   test('modal Colors line reflects the flag color tags', async ({ page }) => {
     // Argentina gained "yellow" (Sun of May) when the reported color tags were fixed.
     await openFlagModalBySearch(page, 'argentina');


### PR DESCRIPTION
## Summary

Part A of #108. The flag grid is rendered by `script.js` with every image `loading="lazy"` and no fetch priority, so the LCP image (the first flag) was deferred.

- The first `EAGER_FLAG_IMAGE_COUNT` (8) above-the-fold images now load **eagerly**.
- The very first image gets **`fetchpriority="high"`** (it's the LCP candidate).
- Everything below the fold stays `loading="lazy"`.

This clears two of the three PSI "LCP request discovery" checks (`lazy load not applied`, `fetchpriority=high should be applied`).

### Trade-offs
- Eager-loading 8 tiny PNGs (~5–11 KiB each) adds a few upfront requests, but they're above the fold and load anyway; the count is kept small to avoid wasting mobile data on off-screen images.

### Not in this PR (deferred)
- **Part B** — a `<head>` preload so the LCP image is *discoverable in the initial document* (the third PSI check). Deferred to #105 so the preload targets the final WebP/right-sized URL and we avoid a double fetch / a hardcoded-first-flag preload that breaks on filtered (`?q=`) landings. See comments on #108 and #105.

Because Part B remains, this **does not fully close #108**.

## Tests
Adds a Playwright assertion that the first grid image is `loading="eager"` + `fetchpriority="high"`, and that a below-the-fold image stays `loading="lazy"`.

Part of #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)
