### PR TITLE
Serve flags as WebP and preload the LCP flag image

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,10 @@
     <meta property="og:description" content="Explore and filter flags from around the world. Search by country name, filter by colors and continents, and discover interesting flag facts.">
     <meta property="og:type" content="website">
     <link rel="canonical" href="https://flagfilter.com/">
+    <!-- Preload the first flag (Andorra) as the LCP image so it is discoverable before
+         the data fetch. The href must match the grid's <img> src exactly (see rebuildFlags
+         in script.js) to avoid a double fetch. -->
+    <link rel="preload" as="image" href="https://flagcdn.com/w320/ad.webp" fetchpriority="high">
     <link rel="stylesheet" href="styles.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">

--- a/script.js
+++ b/script.js
@@ -532,7 +532,7 @@ function rebuildFlags() {
     flags = baseFlagInfo.map((baseInfo) => {
         const info = localizeFlagInfo(baseInfo);
         const code = info.shortname;
-        const url = `https://flagcdn.com/w320/${code}.png`;
+        const url = `https://flagcdn.com/w320/${code}.webp`;
         const tags = info.tags || '';
         const colorTags = ['red', 'blue', 'green', 'yellow', 'white', 'black', 'brown', 'purple', 'orange'];
         const colors = colorTags.filter(color => tags.includes(color));

--- a/tests/e2e/app.spec.js
+++ b/tests/e2e/app.spec.js
@@ -217,6 +217,21 @@ test.describe('Flagfilter UI flows', () => {
     await expect(firstImage).toHaveAttribute('loading', 'eager');
   });
 
+  test('flag images are served as WebP', async ({ page }) => {
+    await expect(page.locator('.flag-card img').first())
+      .toHaveAttribute('src', /flagcdn\.com\/w320\/[a-z]+\.webp$/);
+  });
+
+  test('the first flag is preloaded as the LCP image and matches its grid src', async ({ page }) => {
+    const preload = page.locator('link[rel="preload"][as="image"]');
+    await expect(preload).toHaveAttribute('href', 'https://flagcdn.com/w320/ad.webp');
+    await expect(preload).toHaveAttribute('fetchpriority', 'high');
+
+    // The preload must match the rendered src exactly, otherwise the browser fetches twice.
+    await expect(page.locator('.flag-card img').first())
+      .toHaveAttribute('src', 'https://flagcdn.com/w320/ad.webp');
+  });
+
   test('modal Colors line reflects the flag color tags', async ({ page }) => {
     // Argentina gained "yellow" (Sun of May) when the reported color tags were fixed.
     await openFlagModalBySearch(page, 'argentina');


### PR DESCRIPTION
## Summary

Addresses **#105** (image delivery) and closes **#108** (LCP image).

- **WebP** — the flag image URL switches from `.png` to `.webp` (flagcdn serves both at the same path). WebP is markedly smaller (e.g. Andorra: ~3 KB vs ~6 KB). Applies to both the grid and the detail modal (they share `flag.url`).
- **LCP preload** — a `<head>` `<link rel="preload" as="image" fetchpriority="high">` for the first flag (`ad.webp`) makes the LCP image discoverable *before* the `script.js` → `flaginfo.json` chain. This is the third "LCP request discovery" check from #108 (the first two — eager + `fetchpriority` — shipped in #115). The href matches the grid `src` exactly, so no double fetch.

### Deferred (not in this PR)
- **Responsive `srcset` / right-sizing per DPR.** flagcdn offers multiple widths, and on a 1× desktop the 320px image is larger than the ~200px slot. I left it out on purpose: adding `srcset` would force the preload to use `imagesrcset`/`imagesizes` and risk a **double fetch** of the LCP image, for a modest extra saving on top of WebP. Tracked on #105.

### Trade-off to be aware of
- The preload hardcodes the alphabetically-first flag (`ad`). On `?q=` landings that filter Andorra out, it fetches an unused image (~3 KB) and Lighthouse may warn "preloaded but not used". The common/bare-URL case (what PSI scores) benefits; a static `index.html` can't emit it conditionally.

## Tests
- Grid images are served as WebP.
- The LCP preload exists with `fetchpriority="high"` and its href matches the first grid image's `src` exactly (guards against a double fetch).

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)
