### PR TITLE
Fix heading order and add a main landmark (a11y)

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,12 +68,13 @@
             </div>
         </header>
         
+        <main>
         <div class="filters">
             <div class="filter-section" data-section-id="color">
-                <button class="filter-header" type="button" aria-expanded="true" aria-controls="filter-content-color" onclick="toggleFilterSection(this)">
+                <h2 class="filter-heading"><button class="filter-header" type="button" aria-expanded="true" aria-controls="filter-content-color" onclick="toggleFilterSection(this)">
                     <span class="filter-title">Filter by Color</span>
                     <i class="fas fa-chevron-down filter-icon" aria-hidden="true"></i>
-                </button>
+                </button></h2>
                 <div class="filter-content" id="filter-content-color">
                     <div class="color-filters">
                         <button class="filter-btn" data-color="red">Red</button>
@@ -90,13 +91,13 @@
             </div>
             
             <div class="filter-section" data-section-id="more">
-                <button class="filter-header" type="button" aria-expanded="true" aria-controls="filter-content-more" onclick="toggleFilterSection(this)">
+                <h2 class="filter-heading"><button class="filter-header" type="button" aria-expanded="true" aria-controls="filter-content-more" onclick="toggleFilterSection(this)">
                     <span class="filter-title">More filters</span>
                     <i class="fas fa-chevron-down filter-icon" aria-hidden="true"></i>
-                </button>
+                </button></h2>
                 <div class="filter-content" id="filter-content-more">
                     <div class="compact-filter-group">
-                        <h4>Continent</h4>
+                        <h3>Continent</h3>
                         <div class="continent-filters">
                             <button class="filter-btn" data-continent="africa"><i class="fas fa-mountain"></i> Africa</button>
                             <button class="filter-btn" data-continent="asia"><i class="fas fa-dragon"></i> Asia</button>
@@ -108,7 +109,7 @@
                     </div>
 
                     <div class="compact-filter-group">
-                        <h4>Pattern</h4>
+                        <h3>Pattern</h3>
                         <div class="pattern-filters">
                             <button class="filter-btn" data-pattern="cross"><i class="fas fa-plus"></i> Cross</button>
                             <button class="filter-btn" data-pattern="vertical"><i class="fas fa-arrows-alt-v"></i> Vertical</button>
@@ -120,7 +121,7 @@
                     </div>
 
                     <div class="compact-filter-group">
-                        <h4>Symbol</h4>
+                        <h3>Symbol</h3>
                         <div class="symbol-filters">
                             <button class="filter-btn" data-symbol="flag"><i class="fas fa-flag"></i> Flag</button>
                             <button class="filter-btn" data-symbol="sun"><i class="fas fa-sun"></i> Sun</button>
@@ -133,7 +134,7 @@
                     </div>
 
                     <div class="compact-filter-group">
-                        <h4>Motive</h4>
+                        <h3>Motive</h3>
                         <div class="motive-filters">
                             <button class="filter-btn" data-motive="building"><i class="fas fa-building"></i> Building</button>
                             <button class="filter-btn" data-motive="weapon"><i class="fas fa-crosshairs"></i> Weapon</button>
@@ -149,7 +150,7 @@
                     </div>
 
                     <div class="compact-filter-group">
-                        <h4>People or Clothing</h4>
+                        <h3>People or Clothing</h3>
                         <div class="people-filters">
                             <button class="filter-btn" data-people="face"><i class="fas fa-user"></i> Face</button>
                             <button class="filter-btn" data-people="crown"><i class="fas fa-crown"></i> Crown</button>
@@ -160,7 +161,7 @@
                     </div>
 
                     <div class="compact-filter-group">
-                        <h4>Ideology</h4>
+                        <h3>Ideology</h3>
                         <div class="ideology-filters">
                             <button class="filter-btn" data-ideology="christianity"><i class="fas fa-cross"></i> Christianity</button>
                             <button class="filter-btn" data-ideology="islam"><i class="fas fa-mosque"></i> Islam</button>
@@ -172,7 +173,7 @@
                     </div>
 
                     <div class="compact-filter-group">
-                        <h4>Text</h4>
+                        <h3>Text</h3>
                         <div class="text-filters">
                             <button class="filter-btn" data-text="text"><i class="fas fa-font"></i> Text</button>
                             <button class="filter-btn" data-text="motto"><i class="fas fa-quote-right"></i> Motto</button>
@@ -187,6 +188,7 @@
         <div id="flagGrid" class="flag-grid">
             <!-- Flags will be dynamically inserted here -->
         </div>
+        </main>
     </div>
     <div id="infoModal" class="modal" role="dialog" aria-modal="true" aria-labelledby="infoModalTitle" aria-hidden="true">
         <div class="modal-content">

--- a/script.js
+++ b/script.js
@@ -588,11 +588,11 @@ function applyStaticTranslations() {
     infoButton.setAttribute('aria-label', t('info_button_aria'));
     darkModeToggle.setAttribute('aria-label', t('dark_mode_aria'));
 
-    const filterHeaders = document.querySelectorAll('.filter-section > .filter-header .filter-title');
+    const filterHeaders = document.querySelectorAll('.filter-section .filter-header .filter-title');
     if (filterHeaders[0]) filterHeaders[0].textContent = t('filter_by_color');
     if (filterHeaders[1]) filterHeaders[1].textContent = t('more_filters');
 
-    const groupHeadings = document.querySelectorAll('.compact-filter-group h4');
+    const groupHeadings = document.querySelectorAll('.compact-filter-group h3');
     const groupHeadingKeys = ['continent', 'pattern', 'symbol', 'motive', 'people_or_clothing', 'ideology', 'text'];
     groupHeadings.forEach((heading, index) => {
         heading.textContent = t(groupHeadingKeys[index]);
@@ -1280,7 +1280,7 @@ function syncFilterSectionState(section) {
 
 // Toggle filter section
 function toggleFilterSection(header) {
-    const section = header.parentElement;
+    const section = header.closest('.filter-section');
     section.classList.toggle('collapsed');
     
     // Save the state to localStorage using a stable key that does not change with translations

--- a/styles.css
+++ b/styles.css
@@ -394,6 +394,13 @@ h1 {
     border: 1px solid var(--border-color);
 }
 
+.filter-heading {
+    /* Section title is a heading wrapping the collapse toggle (for valid heading order);
+       neutralize the default <h2> margin/size so the header bar looks unchanged. */
+    margin: 0;
+    font: inherit;
+}
+
 .filter-header {
     display: flex;
     justify-content: space-between;
@@ -1057,7 +1064,7 @@ h1 {
     border: 1px solid var(--border-color);
 }
 
-.compact-filter-group h4 {
+.compact-filter-group h3 {
     margin: 0 0 0.75rem 0;
     font-size: 1rem;
     color: var(--text-color);
@@ -1116,7 +1123,7 @@ h1 {
         gap: 0.5rem;
     }
     
-    .compact-filter-group h4 {
+    .compact-filter-group h3 {
         margin-bottom: 0.25rem;
     }
     

--- a/tests/e2e/app.spec.js
+++ b/tests/e2e/app.spec.js
@@ -232,6 +232,33 @@ test.describe('Flagfilter UI flows', () => {
       .toHaveAttribute('src', 'https://flagcdn.com/w320/ad.webp');
   });
 
+  test('heading levels never skip a level (accessibility heading order)', async ({ page }) => {
+    const levels = await page.evaluate(() =>
+      [...document.querySelectorAll('h1, h2, h3, h4, h5, h6')]
+        .filter((heading) => heading.getClientRects().length > 0)
+        .map((heading) => Number(heading.tagName[1]))
+    );
+
+    expect(levels[0]).toBe(1);
+    for (let i = 1; i < levels.length; i += 1) {
+      expect(levels[i] - levels[i - 1]).toBeLessThanOrEqual(1);
+    }
+  });
+
+  test('the page content is wrapped in a single main landmark', async ({ page }) => {
+    await expect(page.locator('main')).toHaveCount(1);
+    await expect(page.locator('main #flagGrid')).toHaveCount(1);
+  });
+
+  test('filter section heading wraps the toggle and collapse still works', async ({ page }) => {
+    // "More filters" is collapsed by default, hiding its <h3> group headings.
+    const groupHeading = page.locator('.compact-filter-group h3').first();
+    await expect(groupHeading).toBeHidden();
+
+    await page.locator('.filter-section[data-section-id="more"] .filter-header').click();
+    await expect(groupHeading).toBeVisible();
+  });
+
   test('modal Colors line reflects the flag color tags', async ({ page }) => {
     // Argentina gained "yellow" (Sun of May) when the reported color tags were fixed.
     await openFlagModalBySearch(page, 'argentina');


### PR DESCRIPTION
## Summary

Fixes the two accessibility findings from the PageSpeed report (Accessibility 96).

### #111 — heading order (all layers, no skips)
The page jumped from `<h1>` straight to the flag-card `<h3>`s, because the filter `<h4>` group headings live inside the **collapsed-by-default** "More filters" panel and are hidden.

- The two filter section titles ("Filter by Color", "More filters") become real `<h2>` headings that **wrap the collapse toggle button** (the ARIA accordion pattern).
- The filter group headings (`Continent`, `Pattern`, …) are demoted `<h4>` → `<h3>`.
- Flag cards stay `<h3>`.

Visible heading order is now **h1 → h2 → h2 → h3** with no skipped levels, in both the collapsed and expanded states.

### #112 — main landmark
The filters + flag grid are wrapped in a `<main>` element.

## Couplings updated
- `toggleFilterSection()` now resolves the section via `header.closest('.filter-section')` (the toggle is no longer a direct child of `.filter-section`).
- Translation lookups target the new structure: `.filter-section .filter-header .filter-title` and `.compact-filter-group h3`.
- A `.filter-heading { margin: 0; font: inherit; }` reset keeps the header bar visually identical.

## Tests
- Heading levels never skip (visible headings, no jump > 1, first is h1).
- A single `<main>` landmark wraps `#flagGrid`.
- Collapse still works after the `<h2>` wrap (guards the `closest()` fix).

Closes #111, closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)
