### PR TITLE
Preconnect to the flag image host (flagcdn.com)

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,9 @@
     <meta property="og:description" content="Explore and filter flags from around the world. Search by country name, filter by colors and continents, and discover interesting flag facts.">
     <meta property="og:type" content="website">
     <link rel="canonical" href="https://flagfilter.com/">
+    <!-- Warm the connection to the flag image host early (every flag loads from here);
+         no crossorigin since the images are plain non-CORS <img> requests. -->
+    <link rel="preconnect" href="https://flagcdn.com">
     <!-- Preload the first flag (Andorra) as the LCP image so it is discoverable before
          the data fetch. The href must match the grid's <img> src exactly (see rebuildFlags
          in script.js) to avoid a double fetch. -->

--- a/tests/e2e/app.spec.js
+++ b/tests/e2e/app.spec.js
@@ -232,6 +232,10 @@ test.describe('Flagfilter UI flows', () => {
       .toHaveAttribute('src', 'https://flagcdn.com/w320/ad.webp');
   });
 
+  test('preconnects to the flag image host', async ({ page }) => {
+    await expect(page.locator('link[rel="preconnect"][href="https://flagcdn.com"]')).toHaveCount(1);
+  });
+
   test('heading levels never skip a level (accessibility heading order)', async ({ page }) => {
     const levels = await page.evaluate(() =>
       [...document.querySelectorAll('h1, h2, h3, h4, h5, h6')]


### PR DESCRIPTION
## Summary
PSI (mobile, 4 Jun 2026) lists **`https://flagcdn.com` as a preconnect candidate worth ~320 ms of LCP savings** — every flag image loads from there, and the LCP flag now loads eagerly, so warming the connection early shaves the handshake off it.

Adds one `<head>` hint:
```html
<link rel="preconnect" href="https://flagcdn.com">
```
No `crossorigin` — the flags are plain non-CORS `<img>` requests, so the preconnect must match a non-CORS connection.

This is the win that #108's eager LCP image unlocked (it's why #106 was deprioritized until now).

## Tests
Asserts the `preconnect` hint for `flagcdn.com` is present.

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)
