### PR TITLE
Tag China, Vietnam and North Korea with `communism`

### DIFF
--- a/flaginfo.json
+++ b/flaginfo.json
@@ -470,7 +470,7 @@
     "wikipedialink": "https://en.wikipedia.org/wiki/Flag_of_Cameroon"
   },
   {
-    "tags": "china red yellow star",
+    "tags": "china red yellow star communism",
     "shortname": "cn",
     "name": "China",
     "proportion": "2:3",
@@ -1240,7 +1240,7 @@
     "wikipedialink": "https://en.wikipedia.org/wiki/Flag_of_Saint_Kitts_and_Nevis"
   },
   {
-    "tags": "north korea blue white red horizontal star circle",
+    "tags": "north korea blue white red horizontal star circle communism",
     "shortname": "kp",
     "name": "North Korea",
     "proportion": "1:2",
@@ -2439,7 +2439,7 @@
     "wikipedialink": "https://en.wikipedia.org/wiki/Flag_of_the_United_States_Virgin_Islands"
   },
   {
-    "tags": "vietnam red yellow star",
+    "tags": "vietnam red yellow star communism",
     "shortname": "vn",
     "name": "Vietnam",
     "proportion": "2:3",

--- a/tests/e2e/app.spec.js
+++ b/tests/e2e/app.spec.js
@@ -93,6 +93,18 @@ test.describe('Flagfilter UI flows', () => {
     await expect.poll(async () => page.locator('.flag-card').count()).toBeLessThan(initialCards);
   });
 
+  test('communism ideology filter is enabled and returns its tagged flags', async ({ page }) => {
+    // Expand "More filters" (collapsed by default) to reach the ideology buttons.
+    await page.locator('.filter-section[data-section-id="more"] .filter-header').click();
+
+    const communism = page.locator('.filter-btn[data-ideology="communism"]');
+    await expect(communism).toBeEnabled(); // was permanently disabled when no flag carried the tag
+    await communism.click();
+
+    await expect(page.locator('.flag-card')).not.toHaveCount(0);
+    await expect(page.locator('.flag-card h3', { hasText: /^China$/ })).toHaveCount(1);
+  });
+
   test('reset clears combined search and filter state', async ({ page }) => {
     const searchInput = page.locator('#searchInput');
     const yellowFilter = page.locator('.filter-btn[data-color="yellow"]');


### PR DESCRIPTION
## Summary
The **Communism** ideology filter had no matching flags, so `updateFilterButtonStates` kept the button **permanently disabled** — a dead control. This adds the `communism` tag to the three flags whose **Wikipedia** symbolism is explicitly communist/socialist:

| Flag | Wikipedia symbolism |
|---|---|
| China (`cn`) | *"The red represents the Chinese Communist Revolution"*; large star = the CCP |
| North Korea (`kp`) | *"the red star … represents socialism"* / *"red star of communism"* |
| Vietnam (`vn`) | red *"inspired by communist symbolism"*; adopted by the (communist-led) Viet Minh |

**Left out on purpose:** Angola and Mozambique. Per Wikipedia their *official* symbolism is **not** communist (workers/peasants/international solidarity); the communist link is only a resemblance to the Soviet hammer-and-sickle (Angola) or a secondary/contested interpretation the government rejected (Mozambique). Happy to add them if you want a broader "communist-influenced" bar.

Decision method (agreed): for interpretive tags, the flag's **Wikipedia** symbolism section is the deciding source — not the site's own `symbolism` field, and not mere visual resemblance.

## Tests
Adds an e2e test: the Communism filter is now **enabled** and returns its tagged flags (China present).

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)
