### PR TITLE
Defer the main script (off the critical path)

### DIFF
--- a/index.html
+++ b/index.html
@@ -252,6 +252,6 @@
             </div>
         </div>
     </div>
-    <script src="script.js"></script>
+    <script src="script.js" defer></script>
 </body>
 </html> 

--- a/tests/e2e/app.spec.js
+++ b/tests/e2e/app.spec.js
@@ -248,6 +248,10 @@ test.describe('Flagfilter UI flows', () => {
     await expect(page.locator('link[rel="preconnect"][href="https://flagcdn.com"]')).toHaveCount(1);
   });
 
+  test('the main script is deferred (kept off the critical path)', async ({ page }) => {
+    await expect(page.locator('script[src="script.js"][defer]')).toHaveCount(1);
+  });
+
   test('renders icons as inline SVG, not Font Awesome', async ({ page }) => {
     await expect(page.locator('link[href*="font-awesome"]')).toHaveCount(0);
     await expect(page.locator('i.fas')).toHaveCount(0);


### PR DESCRIPTION
## Summary
Adds `defer` to the main `<script>`. PSI lists `script.js` under render-blocking requests; it sits at the end of `<body>` and runs `initApp()` against an already-parsed DOM, so `defer` is safe and lets the browser fetch it in parallel instead of blocking — helping FCP/LCP. No build step.

This is the **actionable part of #109**. The minification half is being **closed as wontfix** (an unscored ~3 KiB diagnostic that overlaps the Brotli compression already in place, and isn't worth introducing a build step to a no-build project).

## Tests
Asserts the main script carries the `defer` attribute.
