### PR TITLE
Add Amazon affiliate "Shop this flag" link to the detail modal

### DIFF
--- a/i18n/ui/en.json
+++ b/i18n/ui/en.json
@@ -80,6 +80,8 @@
   "no_results": "No flags match your search criteria.",
   "learn_more": "Learn more",
   "flag_image_alt": "Flag of {name}",
+  "shop_flag": "Shop the {name} flag",
+  "amazon_disclosure": "As an Amazon Associate I earn from qualifying purchases.",
   "flag_counter_one": "Showing {count} flag",
   "flag_counter_other": "Showing {count} flags",
   "no_information_available": "No information available.",

--- a/i18n/ui/es.json
+++ b/i18n/ui/es.json
@@ -80,6 +80,8 @@
   "no_results": "Ninguna bandera coincide con tu búsqueda.",
   "learn_more": "Saber más",
   "flag_image_alt": "Bandera de {name}",
+  "shop_flag": "Comprar la bandera de {name}",
+  "amazon_disclosure": "Como Afiliado de Amazon, gano con las compras que cumplen los requisitos.",
   "flag_counter_one": "Mostrando {count} bandera",
   "flag_counter_other": "Mostrando {count} banderas",
   "no_information_available": "No hay información disponible.",

--- a/script.js
+++ b/script.js
@@ -15,6 +15,7 @@ let currentLanguage = 'en';
 const SUPPORTED_LANGUAGES = ['en', 'es'];
 const DEFAULT_LANGUAGE = 'en';
 const QUERY_FILTER_DATA_KEYS = ['color', 'continent', 'pattern', 'symbol', 'motive', 'people', 'ideology', 'text'];
+const AMAZON_ASSOCIATE_TAG = 'flagfilter-20';
 
 function getLanguageFromUrl() {
     const lang = new URLSearchParams(window.location.search).get('lang');
@@ -867,6 +868,12 @@ function showFlagInfoModal(flag) {
     const processedSymbolism = processHtmlContent(flag.info.symbolism || t('no_information_available'));
     const processedFunfacts = processHtmlContent(flag.info.funfacts || t('no_fun_facts_available'));
     
+    // Amazon affiliate search link — uses the English base name (so the query works
+    // in any UI language) with parenthetical aliases stripped. See #126.
+    const baseInfo = getBaseFlagInfoByCode(flag.code);
+    const englishName = (baseInfo?.name || flag.name).replace(/\s*\(.*?\)\s*/g, ' ').trim();
+    const shopUrl = `https://www.amazon.com/s?k=${encodeURIComponent(englishName + ' flag')}&tag=${AMAZON_ASSOCIATE_TAG}`;
+
     // Add flag information
     flagInfo.innerHTML = `
         <h2 id="flagModalTitle">${flag.name}</h2>
@@ -876,8 +883,10 @@ function showFlagInfoModal(flag) {
         <p><strong>${t('colors_label')}:</strong> ${flag.colors.join(', ')}</p>
         <div class="modal-actions">
             <a href="${flag.info.wikipedialink}" target="_blank" rel="noopener noreferrer" class="wiki-link">${t('read_more_wikipedia')}</a>
+            <a href="${shopUrl}" target="_blank" rel="noopener noreferrer sponsored nofollow" class="shop-link">${t('shop_flag', { name: flag.name })}</a>
             <button class="report-issue-btn" aria-expanded="false" aria-controls="reportFormPanel">${t('report_issue')}</button>
         </div>
+        <p class="affiliate-disclosure">${t('amazon_disclosure')}</p>
     `;
     
     // Create report issue form (initially hidden)

--- a/styles.css
+++ b/styles.css
@@ -1027,6 +1027,33 @@ h1 {
     margin-top: 1rem;
 }
 
+/* Affiliate "Shop" link — an outline button so it reads as a secondary,
+   commercial action distinct from the filled Wikipedia button. */
+.flag-info-details .shop-link {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.5rem 1rem;
+    background-color: transparent;
+    color: var(--primary-color);
+    border: 1px solid var(--primary-color);
+    border-radius: 6px;
+    font-weight: 500;
+    text-decoration: none;
+    transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.flag-info-details .shop-link:hover {
+    background-color: var(--primary-color);
+    color: white;
+}
+
+.affiliate-disclosure {
+    margin-top: 0.6rem;
+    font-size: 0.75rem;
+    opacity: 0.6;
+}
+
 /* Increase specificity for the Wikipedia link */
 .flag-info-details .wiki-link,
 .wiki-link {

--- a/tests/e2e/app.spec.js
+++ b/tests/e2e/app.spec.js
@@ -340,6 +340,28 @@ test.describe('Flagfilter UI flows', () => {
     await expect(groupHeading).toBeVisible();
   });
 
+  test('flag modal has an Amazon affiliate shop link with disclosure', async ({ page }) => {
+    await openFlagModalBySearch(page, 'sweden');
+    const shop = page.locator('.shop-link');
+    await expect(shop).toHaveAttribute('href', 'https://www.amazon.com/s?k=Sweden%20flag&tag=flagfilter-20');
+    await expect(shop).toHaveAttribute('rel', /sponsored/);
+    await expect(page.locator('.affiliate-disclosure')).toContainText('Amazon Associate');
+  });
+
+  test('shop link uses the English flag name even in the Spanish UI', async ({ page }) => {
+    await gotoApp(page, 'es');
+    await openFlagModalBySearch(page, 'sweden');
+    const shop = page.locator('.shop-link');
+    await expect(shop).toHaveAttribute('href', /k=Sweden%20flag&tag=flagfilter-20/); // English search query
+    await expect(shop).toContainText('Suecia'); // Spanish label
+  });
+
+  test('shop link strips parenthetical aliases from the search query', async ({ page }) => {
+    await openFlagModalBySearch(page, 'timor-leste');
+    await expect(page.locator('.shop-link'))
+      .toHaveAttribute('href', 'https://www.amazon.com/s?k=Timor-Leste%20flag&tag=flagfilter-20');
+  });
+
   test('modal Colors line reflects the flag color tags', async ({ page }) => {
     // Argentina gained "yellow" (Sun of May) when the reported color tags were fixed.
     await openFlagModalBySearch(page, 'argentina');


### PR DESCRIPTION
## Summary
Adds a tasteful **Amazon affiliate "Shop the {name} flag" link** to each flag's detail modal, plus an affiliate disclosure — the first income stream (#126).

- **Search-link template** (`amazon.com/s?k=…&tag=flagfilter-20`) using the **English base name** with parenthetical aliases stripped, so the query is right in any UI language: `Sweden flag`, `Timor-Leste flag`, `United Arab Emirates flag`.
- **`rel="noopener noreferrer sponsored nofollow"`** — Google's paid-link requirement.
- **Disclosure** with Amazon's exact wording — *"As an Amazon Associate I earn from qualifying purchases."* — shown in every flag modal, localized for Spanish.
- Styled as an **outline** button so it reads as a secondary, commercial action distinct from the filled Wikipedia button.
- **Plain link only** — no tracking script → no perf or cookie-consent cost.

Amazon's own Creator/Associates page confirms *"links can be to … pages of search results …"* are commissionable, so the approach is policy-compliant. Allegiance (US-flag specialist override) is deferred to a follow-up per the decision on #126.

## Tests
- Shop link present with exact href + `rel=sponsored` + disclosure text.
- Uses the **English** name even in the Spanish UI (query = `Sweden flag`, label = "Suecia").
- Strips parentheses (`Timor-Leste flag`).

## Note
This is a **visual** change (new button + disclosure line in the modal) — please eyeball the branch preview before merging; not auto-merging. The link is live with `tag=flagfilter-20` (the account clock is already running).

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)
