### PR TITLE
Use a w640 flag image in the detail modal (sharper)

### DIFF
--- a/script.js
+++ b/script.js
@@ -848,7 +848,10 @@ function showFlagInfoModal(flag) {
     
     // Create flag image
     const flagImage = document.createElement('img');
-    flagImage.src = flag.url;
+    // Use a higher-resolution source for the modal — it's displayed up to 400px wide
+    // (more on HiDPI screens), so w320 looked soft. The grid keeps w320 for performance;
+    // this w640 fetch only happens when a flag is opened (lazy, not the LCP image).
+    flagImage.src = flag.url.replace('/w320/', '/w640/');
     flagImage.alt = t('flag_image_alt', { name: flag.name });
     flagImage.className = 'modal-flag-image';
 

--- a/tests/e2e/app.spec.js
+++ b/tests/e2e/app.spec.js
@@ -206,6 +206,13 @@ test.describe('Flagfilter UI flows', () => {
     await expect(modalImage).toHaveAttribute('height', '200');
   });
 
+  test('modal flag image uses a higher-resolution (w640) source than the grid', async ({ page }) => {
+    // Grid stays w320 for performance; the modal uses w640 for a crisp detail view.
+    await expect(page.locator('.flag-card img').first()).toHaveAttribute('src', /\/w320\//);
+    await openFlagModalBySearch(page, 'sweden');
+    await expect(page.locator('.modal-flag-image')).toHaveAttribute('src', /\/w640\/se\.webp$/);
+  });
+
   test('first flag image is eager and high priority for LCP, later ones stay lazy', async ({ page }) => {
     const firstImage = page.locator('.flag-card img').first();
     await expect(firstImage).toHaveAttribute('fetchpriority', 'high');


### PR DESCRIPTION
## Summary
The flag images looked soft in the **detail modal**. Root cause is **resolution, not the WebP switch**: flagcdn's WebP is *lossless and identical in size* to the PNG (e.g. Kiribati 320×160 in both), so `.png`→`.webp` didn't reduce quality. The modal is `max-width: 400px` (and ~2× on HiDPI), so a **320px source was being upscaled** — most visible on detailed emblems like Kiribati's frigatebird/sun.

Fix: the modal now uses flagcdn's **w640** (`flag.url.replace('/w320/', '/w640/')`).

- The **grid keeps w320** (the performance/LCP-sensitive surface is untouched).
- The w640 is fetched **only when a modal opens** (lazy, not the LCP image), ~6 KB, and cached for 31 days after — so the one-time extra download is negligible.
- CLS reservation is unchanged (the width/height attributes still encode the same aspect ratio).

## Tests
Asserts the modal image src is `…/w640/…webp` while the grid image stays `…/w320/…`.

## Note
Visual change — please glance at a flag's detail view on the branch preview to confirm it's crisp; not auto-merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
