### PR TITLE
Localize the modal Colors line

### DIFF
--- a/script.js
+++ b/script.js
@@ -883,7 +883,7 @@ function showFlagInfoModal(flag) {
         <p><strong>${t('adopted_label')}:</strong> ${flag.info.adopted || t('unknown')}</p>
         <p><strong>${t('symbolism_label')}:</strong> ${processedSymbolism}</p>
         <p><strong>${t('fun_facts_label')}:</strong> ${processedFunfacts}</p>
-        <p><strong>${t('colors_label')}:</strong> ${flag.colors.join(', ')}</p>
+        <p><strong>${t('colors_label')}:</strong> ${flag.colors.map((color) => t(`color_${color}`)).join(', ')}</p>
         <div class="modal-actions">
             <a href="${flag.info.wikipedialink}" target="_blank" rel="noopener noreferrer" class="wiki-link">${t('read_more_wikipedia')}</a>
             <a href="${shopUrl}" target="_blank" rel="noopener noreferrer sponsored nofollow" class="shop-link">${t('shop_flag', { name: flag.name })}</a>

--- a/tests/e2e/app.spec.js
+++ b/tests/e2e/app.spec.js
@@ -373,14 +373,22 @@ test.describe('Flagfilter UI flows', () => {
     // Argentina gained "yellow" (Sun of May) when the reported color tags were fixed.
     await openFlagModalBySearch(page, 'argentina');
     const argentinaColors = page.locator('.flag-info-details p', { hasText: 'Colors:' });
-    await expect(argentinaColors).toContainText('yellow');
+    await expect(argentinaColors).toContainText('Yellow'); // localized label (was raw "yellow")
   });
 
   test('modal Colors line surfaces brown for the Cocos Islands', async ({ page }) => {
     // "brown" was promoted to a recognized color so the Cocos palm tree shows up.
     await openFlagModalBySearch(page, 'cocos');
     const cocosColors = page.locator('.flag-info-details p', { hasText: 'Colors:' });
-    await expect(cocosColors).toContainText('brown');
+    await expect(cocosColors).toContainText('Brown');
+  });
+
+  test('modal Colors line is localized in the Spanish UI', async ({ page }) => {
+    await gotoApp(page, 'es');
+    await openFlagModalBySearch(page, 'sweden');
+    const colors = page.locator('.flag-info-details p', { hasText: 'Colores:' });
+    await expect(colors).toContainText('Azul'); // localized, not the English "blue"
+    await expect(colors).not.toContainText('blue');
   });
 
   test('English modal content renders inline flag links', async ({ page }) => {


### PR DESCRIPTION
## Summary
The detail modal listed colours from the raw English tag words (`flag.colors`), so the Spanish UI showed **"Colores: red, blue"** instead of **"Colores: Rojo, Azul"** (the label was translated, the values weren't).

Fix: map each colour through the existing `color_*` keys, e.g. `flag.colors.map(c => t(\`color_${c}\`))`. These keys already exist for all nine colours in both `en.json` and `es.json` (the filter buttons use them).

Side effect: the **English** labels are now Title-cased (Red, Blue, …), matching the filter buttons.

## Tests
- Updated the two colour tests to the Title-cased labels (Yellow / Brown).
- Added a test that the Spanish modal shows localized colours (Azul, not "blue").

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)
