### PR TITLE
Add security headers + report-only CSP

### DIFF
--- a/_headers
+++ b/_headers
@@ -1,3 +1,17 @@
+# Security headers (apply to every response).
+# CSP starts in Report-Only so it cannot break production: verify there are no
+# violations in the live browser console (it surfaces Cloudflare-injected resources
+# like email-decode, the Fonts <style>, and any Insights beacon), then switch the
+# header name to Content-Security-Policy to enforce. Trusted Types is deferred (the
+# app uses innerHTML in several places).
+/*
+  Strict-Transport-Security: max-age=31536000; includeSubDomains
+  X-Frame-Options: DENY
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin
+  Cross-Origin-Opener-Policy: same-origin
+  Content-Security-Policy-Report-Only: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' https://flagcdn.com data:; font-src 'self' https://fonts.gstatic.com; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests
+
 /index.html
   Cache-Control: public, max-age=0, must-revalidate
 

--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
 </head>
 <body>
-<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" style="position:absolute;width:0;height:0;overflow:hidden">
+<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" class="sprite">
   <symbol id="i-arrows-alt-h" viewBox="0 0 512 512"><path d="M504.3 273.6c4.9-4.5 7.7-10.9 7.7-17.6s-2.8-13-7.7-17.6l-112-104c-7-6.5-17.2-8.2-25.9-4.4s-14.4 12.5-14.4 22l0 56-192 0 0-56c0-9.5-5.7-18.2-14.4-22s-18.9-2.1-25.9 4.4l-112 104C2.8 243 0 249.3 0 256s2.8 13 7.7 17.6l112 104c7 6.5 17.2 8.2 25.9 4.4s14.4-12.5 14.4-22l0-56 192 0 0 56c0 9.5 5.7 18.2 14.4 22s18.9 2.1 25.9-4.4l112-104z"/></symbol>
   <symbol id="i-arrows-alt-v" viewBox="0 0 256 512"><path d="M145.6 7.7C141 2.8 134.7 0 128 0s-13 2.8-17.6 7.7l-104 112c-6.5 7-8.2 17.2-4.4 25.9S14.5 160 24 160H80V352H24c-9.5 0-18.2 5.7-22 14.4s-2.1 18.9 4.4 25.9l104 112c4.5 4.9 10.9 7.7 17.6 7.7s13-2.8 17.6-7.7l104-112c6.5-7 8.2-17.2 4.4-25.9s-12.5-14.4-22-14.4H176V160h56c9.5 0 18.2-5.7 22-14.4s2.1-18.9-4.4-25.9l-104-112z"/></symbol>
   <symbol id="i-building" viewBox="0 0 384 512"><path d="M48 0C21.5 0 0 21.5 0 48V464c0 26.5 21.5 48 48 48h96V432c0-26.5 21.5-48 48-48s48 21.5 48 48v80h96c26.5 0 48-21.5 48-48V48c0-26.5-21.5-48-48-48H48zM64 240c0-8.8 7.2-16 16-16h32c8.8 0 16 7.2 16 16v32c0 8.8-7.2 16-16 16H80c-8.8 0-16-7.2-16-16V240zm112-16h32c8.8 0 16 7.2 16 16v32c0 8.8-7.2 16-16 16H176c-8.8 0-16-7.2-16-16V240c0-8.8 7.2-16 16-16zm80 16c0-8.8 7.2-16 16-16h32c8.8 0 16 7.2 16 16v32c0 8.8-7.2 16-16 16H272c-8.8 0-16-7.2-16-16V240zM80 96h32c8.8 0 16 7.2 16 16v32c0 8.8-7.2 16-16 16H80c-8.8 0-16-7.2-16-16V112c0-8.8 7.2-16 16-16zm80 16c0-8.8 7.2-16 16-16h32c8.8 0 16 7.2 16 16v32c0 8.8-7.2 16-16 16H176c-8.8 0-16-7.2-16-16V112zM272 96h32c8.8 0 16 7.2 16 16v32c0 8.8-7.2 16-16 16H272c-8.8 0-16-7.2-16-16V112c0-8.8 7.2-16 16-16z"/></symbol>
@@ -122,7 +122,7 @@
         <main>
         <div class="filters">
             <div class="filter-section" data-section-id="color">
-                <h2 class="filter-heading"><button class="filter-header" type="button" aria-expanded="true" aria-controls="filter-content-color" onclick="toggleFilterSection(this)">
+                <h2 class="filter-heading"><button class="filter-header" type="button" aria-expanded="true" aria-controls="filter-content-color">
                     <span class="filter-title">Filter by Color</span>
                     <svg class="icon filter-icon" aria-hidden="true"><use href="#i-chevron-down"></use></svg>
                 </button></h2>
@@ -142,7 +142,7 @@
             </div>
             
             <div class="filter-section" data-section-id="more">
-                <h2 class="filter-heading"><button class="filter-header" type="button" aria-expanded="true" aria-controls="filter-content-more" onclick="toggleFilterSection(this)">
+                <h2 class="filter-heading"><button class="filter-header" type="button" aria-expanded="true" aria-controls="filter-content-more">
                     <span class="filter-title">More filters</span>
                     <svg class="icon filter-icon" aria-hidden="true"><use href="#i-chevron-down"></use></svg>
                 </button></h2>

--- a/script.js
+++ b/script.js
@@ -1312,6 +1312,13 @@ function initializeFilterSections() {
             section.classList.add('collapsed');
         }
         syncFilterSectionState(section);
+
+        // Bind the collapse toggle here instead of an inline onclick, so the CSP can
+        // use a strict script-src 'self' (no 'unsafe-inline').
+        const header = section.querySelector('.filter-header');
+        if (header) {
+            header.addEventListener('click', () => toggleFilterSection(header));
+        }
     });
 }
 

--- a/styles.css
+++ b/styles.css
@@ -60,6 +60,14 @@
     border: 0;
 }
 
+/* Hides the inline <symbol> sprite (moved off an inline style= so the CSP can be strict). */
+.sprite {
+    position: absolute;
+    width: 0;
+    height: 0;
+    overflow: hidden;
+}
+
 .icon {
     width: 1em;
     height: 1em;


### PR DESCRIPTION
## Summary
Addresses the Best Practices "Trust & Safety" items from #113 (all unscored hardening; BP is already 100), staged to avoid breaking the live site.

### Enforced now (low risk)
- `Strict-Transport-Security: max-age=31536000; includeSubDomains`
- `X-Frame-Options: DENY` (clickjacking)
- `X-Content-Type-Options: nosniff`
- `Referrer-Policy: strict-origin-when-cross-origin`
- `Cross-Origin-Opener-Policy: same-origin`

These cover the HSTS, frame-control and COOP findings.

### CSP — Report-Only first (deliberate)
The CSP ships as **`Content-Security-Policy-Report-Only`** so it **cannot break production**. I can't validate it from here: neither the e2e server (ignores `_headers`) nor the `*.pages.dev` preview (no Cloudflare Fonts / email-decode, which are zone-only) reproduces production. Report-only lets the live console reveal anything the policy is missing (Cloudflare's email-decode script, the Fonts `<style>`, a possible Insights beacon) without taking the site down.

Target policy:
```
default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline';
img-src 'self' https://flagcdn.com data:; font-src 'self' https://fonts.gstatic.com;
connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self';
object-src 'none'; upgrade-insecure-requests
```

To make a strict **`script-src 'self'`** (no `'unsafe-inline'`) possible:
- the two inline `onclick="toggleFilterSection(this)"` handlers move to `addEventListener` (collapse behaviour unchanged, covered by the existing collapse e2e test),
- the sprite's inline `style=` becomes a `.sprite` CSS class.

`style-src` keeps `'unsafe-inline'` because Cloudflare Fonts injects an inline `<style>` block we can't nonce.

### Deferred
- **Trusted Types** (the "DOM-based XSS" item): the app uses `innerHTML` in ~10 places, so `require-trusted-types-for 'script'` needs a real refactor. Left for later; lower risk since it's our own data.

## Verify → enforce (next step)
This is **not auto-merged** — `_headers` only takes effect on the live zone, which I can't test. After merge:
1. Load the live site, open DevTools console, click around (open a flag, switch language, expand "More filters", submit a report).
2. Note any **"[Report Only] Refused to…"** CSP messages.
3. Tell me what shows up; I'll adjust the policy, then flip `Content-Security-Policy-Report-Only` → `Content-Security-Policy` to enforce (one-line follow-up that closes #113's CSP item).

Part of #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)
