### PR TITLE
Enforce the Content-Security-Policy

### DIFF
--- a/_headers
+++ b/_headers
@@ -6,13 +6,15 @@
 # base-uri/form-action/frame-ancestors/object-src. Trusted Types is out of scope (the
 # app uses innerHTML), so inline-script XSS is not blocked — acceptable here since the
 # page only renders first-party data.
+# fonts.googleapis.com / fonts.gstatic.com are allowed for the case where Cloudflare
+# Fonts falls back to (or is disabled and serves) the original Google Fonts <link>.
 /*
   Strict-Transport-Security: max-age=31536000; includeSubDomains
   X-Frame-Options: DENY
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
   Cross-Origin-Opener-Policy: same-origin
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' https://flagcdn.com data:; font-src 'self' https://fonts.gstatic.com; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' https://flagcdn.com data:; font-src 'self' https://fonts.gstatic.com; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests
 
 /index.html
   Cache-Control: public, max-age=0, must-revalidate

--- a/_headers
+++ b/_headers
@@ -1,16 +1,18 @@
 # Security headers (apply to every response).
-# CSP starts in Report-Only so it cannot break production: verify there are no
-# violations in the live browser console (it surfaces Cloudflare-injected resources
-# like email-decode, the Fonts <style>, and any Insights beacon), then switch the
-# header name to Content-Security-Policy to enforce. Trusted Types is deferred (the
-# app uses innerHTML in several places).
+# CSP is enforced with 'unsafe-inline' on script-src and style-src: Cloudflare injects
+# an inline <script> (Email Obfuscation) and an inline <style> (Cloudflare Fonts) that
+# we don't control, and we chose not to hash them (maintenance) or disable the features.
+# The policy still blocks external script/resource injection and restricts
+# base-uri/form-action/frame-ancestors/object-src. Trusted Types is out of scope (the
+# app uses innerHTML), so inline-script XSS is not blocked — acceptable here since the
+# page only renders first-party data.
 /*
   Strict-Transport-Security: max-age=31536000; includeSubDomains
   X-Frame-Options: DENY
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
   Cross-Origin-Opener-Policy: same-origin
-  Content-Security-Policy-Report-Only: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' https://flagcdn.com data:; font-src 'self' https://fonts.gstatic.com; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' https://flagcdn.com data:; font-src 'self' https://fonts.gstatic.com; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests
 
 /index.html
   Cache-Control: public, max-age=0, must-revalidate


### PR DESCRIPTION
## Summary
Flips the CSP from `Report-Only` to **enforced**, with `'unsafe-inline'` added to `script-src` (and kept on `style-src`).

Why `'unsafe-inline'`: your production report-only check showed the only real violations were **Cloudflare's injected inline script** (Email Obfuscation) — everything else was browser-extension noise, and images/fonts/connect were clean. You preferred not to hash the Cloudflare script (maintenance) or disable Email Obfuscation (spam protection), so `'unsafe-inline'` is the maintenance-free middle ground.

The enforced policy still provides real hardening:
- `default-src 'self'` + `script-src 'self' 'unsafe-inline'` — blocks **external** script/resource injection
- `object-src 'none'`, `base-uri 'self'`, `form-action 'self'`, `frame-ancestors 'none'`
- restricted `img-src` (flagcdn) / `font-src` / `connect-src`

**Trade-off (honest):** inline-script XSS is *not* blocked, and Lighthouse's "strong CSP" item stays flagged — but that item is **unscored**, and the page only renders first-party data, so the residual risk is low. Trusted Types remains out of scope.

## Note — not auto-merging
`_headers` only takes effect on the live zone, and this is the **enforcing** flip (a wrong policy would break the site). After merge, please load **flagfilter.com** (hotspot) and sanity-check: fonts/flags/icons render, the detail modal and report form work. If anything's off, revert this one-line change (back to `-Report-Only`) and ping me.

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)
