### PR TITLE
Drop redundant scroll-to-top from title reset

### DIFF
--- a/script.js
+++ b/script.js
@@ -1379,7 +1379,6 @@ if (titleReset) {
     titleReset.addEventListener('click', () => {
         resetAllFilters();
         resetFilterSectionsToDefault();
-        window.scrollTo(0, 0);
     });
 }
 


### PR DESCRIPTION
Follow-up cleanup. The header is not sticky (the only `position: fixed` in the CSS is the modal), so the "Flagfilter" title is only clickable when it's already at/near the top of the page — meaning `window.scrollTo(0, 0)` in the title reset was effectively a no-op. Removing it keeps the reset behaviour honest and minimal.

Section-collapse + filter/search/`?q=` reset are unchanged.