### PR TITLE
Allow Cloudflare Insights beacon origins in CSP

### DIFF
--- a/_headers
+++ b/_headers
@@ -8,13 +8,16 @@
 # page only renders first-party data.
 # fonts.googleapis.com / fonts.gstatic.com are allowed for the case where Cloudflare
 # Fonts falls back to (or is disabled and serves) the original Google Fonts <link>.
+# static.cloudflareinsights.com (script-src) and cloudflareinsights.com (connect-src)
+# are allowed so Cloudflare Web Analytics' beacon can load and report once automatic
+# injection is enabled in the dashboard; without these the enforced CSP would block it.
 /*
   Strict-Transport-Security: max-age=31536000; includeSubDomains
   X-Frame-Options: DENY
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
   Cross-Origin-Opener-Policy: same-origin
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' https://flagcdn.com data:; font-src 'self' https://fonts.gstatic.com; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' https://flagcdn.com data:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://cloudflareinsights.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests
 
 /index.html
   Cache-Control: public, max-age=0, must-revalidate


### PR DESCRIPTION
Adds the two Cloudflare Web Analytics beacon origins to the enforced CSP so we can start collecting real (human-browser) analytics — referrers, unique humans, geography — which we currently can't see.

### Why
- `static.cloudflareinsights.com` → `script-src` (loads `beacon.min.js`)
- `cloudflareinsights.com` → `connect-src` (the beacon's RUM reporting POST)

Without these, once Web Analytics automatic injection is enabled the enforced CSP blocks both the script load and its report, so the dashboard stays empty.

### Trade-off
This slightly loosens the CSP we just tightened — two external origins are now allowed. They're Cloudflare's own first-party analytics (low risk, no third-party JS beyond CF itself), but it is a small walk-back of `script-src 'self'`.

### Note
The CSP change alone produces no data — Cloudflare **Web Analytics (automatic injection)** must also be enabled in the dashboard. This PR just makes the site CSP-ready so the beacon isn't blocked when that's turned on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)