### PR TITLE
Document session learnings in AGENTS.md; add CLAUDE.md importing it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,9 @@ This file documents how AI coding assistants should work in this repository.
 - Static frontend files live in the repository root.
 - API endpoint lives in `functions/api/report-issue.js`.
 - GitHub communication for this project should be written in English.
+- The flag detail modal contains Amazon Associates shop links (tag `flagfilter-20`).
+  Affiliate links must keep `rel="noopener noreferrer sponsored nofollow"` and the
+  localized disclosure line next to them.
 
 ## Branching and git workflow
 
@@ -25,6 +28,23 @@ This file documents how AI coding assistants should work in this repository.
 - PR descriptions should be provided in Markdown.
 - Keep PRs focused on one theme when possible.
 - Prefer iterative PRs over large bundled changes.
+- PRs are reviewed by the Codex bot; request a (re-)review by commenting `@codex review`.
+- Squash-merge once CI is green and review feedback is resolved; head branches are
+  auto-deleted on merge, so also delete the local branch afterwards.
+
+## Frontend conventions
+
+- The Content-Security-Policy in `_headers` is enforced. Any new external origin
+  (script, stylesheet, image, font, fetch/beacon target) must be added to the matching
+  CSP directive in the same PR, or the browser will silently block it in production.
+- No inline event handlers (`onclick="..."`). Bind listeners with `addEventListener`
+  so markup stays compatible with the CSP.
+- Every user-facing string — including `aria-label`s and tooltips — needs keys in both
+  `i18n/ui/en.json` and `i18n/ui/es.json`.
+- Icons are an inline SVG `<symbol>` sprite in `index.html` (Font Awesome 6 solid
+  paths, ids `#i-*`). Add new icons to the sprite; do not add icon CDNs or webfonts.
+- `index.html` preloads the first flag image (`w320/ad.webp`) as the LCP image.
+  Any change that alters which flag renders first must update that preload.
 
 ## Testing strategy
 
@@ -39,6 +59,24 @@ This file documents how AI coding assistants should work in this repository.
 - Do not assume Workers-only bindings are available in Pages Functions.
 - If something depends on Cloudflare runtime capabilities, verify Pages compatibility before documenting or relying on it.
 - Keep secrets out of the repository. Use Cloudflare secrets or environment variables where appropriate.
+- Zone feature state (as of 2026-07): Cloudflare Fonts enabled (rewrites the Google
+  Fonts `<link>` to same-origin; the CSP still allows the Google Fonts origins as its
+  fallback), Email Obfuscation enabled (keep it — its inline script is why script-src
+  has 'unsafe-inline'), Rocket Loader disabled, Web Analytics enabled (its beacon
+  origins are allowed in the CSP).
+- Web Analytics undercounts by design: Edge Tracking Prevention, Safari ITP and ad
+  blockers block the beacon. Use it for traffic composition (referrers, paths), not
+  absolute counts. Zone-level "unique visitors" counts include bots/crawlers.
+
+## Environment constraints (verification)
+
+- The assistant sandbox typically has no Node/npm; Playwright runs in CI
+  (`.github/workflows/ui-tests.yml`), not locally. Write tests, let CI validate them.
+- The sandbox may not be able to reach `flagfilter.com` (DNS). Verify production
+  behavior via the `*.pages.dev` preview deployment or ask the user to check.
+- `_headers` (CSP/security headers) cannot be exercised by the Playwright suite —
+  tests run against a plain static file server. Changes there need verification on
+  the deployed site after merge.
 
 ## Legacy files
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,8 @@
+# CLAUDE.md
+
+@AGENTS.md
+
+All repository guidance for AI coding assistants lives in `AGENTS.md` (the
+cross-tool standard also read by Codex and others). Keep `AGENTS.md` as the
+single source of truth; this file only imports it so Claude Code picks it up
+automatically.


### PR DESCRIPTION
Docs-only. Captures the working conventions established over the recent sessions so any AI assistant (Codex, Claude, ...) starts with the same ground rules:

- **Frontend conventions:** enforced CSP in `_headers` (new external origins must ship in the same PR; no inline `onclick`), en+es i18n keys for every user-facing string incl. aria-labels, inline SVG sprite for icons (no icon CDNs), and the LCP preload ↔ first-flag coupling.
- **PR workflow:** Codex reviews via `@codex review`, squash-merge on green with feedback resolved, auto-deleted head branches.
- **Cloudflare state (2026-07):** CF Fonts on, Email Obfuscation on (reason script-src has 'unsafe-inline'), Rocket Loader off, Web Analytics on + beacon origins in CSP; undercounting caveats.
- **Verification constraints:** no Node/Playwright in the assistant sandbox (CI validates), `flagfilter.com` may be unreachable from the sandbox, `_headers` not exercisable by the e2e suite.

Also adds a thin `CLAUDE.md` that imports `AGENTS.md`, so Claude Code auto-loads the same instructions while `AGENTS.md` remains the single source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)