### PR TITLE
Drop dead backdrop-filter and add -webkit-user-select for Safari (#137)

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -419,6 +419,7 @@ h1 {
     font-size: 1.1rem;
     line-height: 1;
     pointer-events: none;
+    -webkit-user-select: none;
     user-select: none;
 }
 
@@ -448,6 +449,7 @@ h1 {
     align-items: center;
     padding: 1rem 1.5rem;
     cursor: pointer;
+    -webkit-user-select: none;
     user-select: none;
     -webkit-tap-highlight-color: transparent;
     transition: background-color 0.2s ease;
@@ -723,7 +725,6 @@ h1 {
     box-shadow: 0 4px 6px var(--shadow-color);
     transition: transform 0.2s ease, box-shadow 0.2s ease;
     position: relative;
-    backdrop-filter: blur(8px);
     border: 1px solid var(--border-color);
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
Closes #137. CSS-only, three edits:

- **`.flag-card`: `backdrop-filter: blur(8px)` removed** instead of prefixed. `--card-bg` is fully opaque in both themes (`#ffffff` / `#1f2937`), so the blur is invisible in every browser — it was dead code that also forced compositing layers across ~250 cards. (If a translucent card design ever lands, re-add it together with `-webkit-backdrop-filter`.)
- **`-webkit-user-select: none`** added next to both `user-select: none` rules (search icon overlay, `.filter-header`) so Safari/iOS also suppresses accidental text selection on the collapse controls — relevant since most of our search traffic is mobile.

No behaviour change on Chromium/Firefox. Not testable in CI (Playwright runs Chromium only); the change is purely additive/subtractive CSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)