### PR TITLE
Search: separate haystack fields with a sentinel so queries can't match across boundaries (#151)

### DIFF
--- a/script.js
+++ b/script.js
@@ -332,8 +332,12 @@ function rebuildFlags() {
         // Precompute one normalized search haystack per flag (localized name +
         // English base name + code + tags), so matchesSearchTerm becomes a single
         // includes() that folds diacritics and works regardless of UI language.
-        // See #144.
-        const searchText = normalizeQueryValue(`${info.name || ''} ${baseInfo.name || ''} ${code} ${tags}`);
+        // Each field is normalized separately and joined with a NUL sentinel that
+        // the query normalization always strips, so a search term can never match
+        // across a field boundary (e.g. "spain es"). See #144 and #151.
+        const searchText = [info.name || '', baseInfo.name || '', code, tags]
+            .map(normalizeQueryValue)
+            .join(String.fromCharCode(0));
 
         return {
             code,

--- a/tests/e2e/app.spec.js
+++ b/tests/e2e/app.spec.js
@@ -253,6 +253,22 @@ test.describe('Flagfilter UI flows', () => {
     await expect(page.locator('.flag-card h3')).toHaveText(['España']);
   });
 
+  test('search cannot match across field boundaries', async ({ page }) => {
+    // "spain es" would match Spain if the name field flowed into the code
+    // field; with sentinel-separated haystack fields it finds nothing. See #151.
+    await page.locator('#searchInput').fill('spain es');
+    await expect(page.locator('.flag-card')).toHaveCount(0);
+    await expect(page.locator('.no-results')).toBeVisible();
+  });
+
+  test('Spanish UI search cannot match across the translated and base name', async ({ page }) => {
+    // "espana spain" spans the localized-name and base-name fields. See #151.
+    await gotoApp(page, 'es');
+    await page.locator('#searchInput').fill('espana spain');
+    await expect(page.locator('.flag-card')).toHaveCount(0);
+    await expect(page.locator('.no-results')).toBeVisible();
+  });
+
   test('search containing only punctuation shows the no-results message', async ({ page }) => {
     await page.locator('#searchInput').fill('!!!');
     await expect(page.locator('.flag-card')).toHaveCount(0);


### PR DESCRIPTION
Closes #151.

## Problem

The normalized search haystack built in `rebuildFlags()` (#144) concatenated the localized name, English base name, code and tags into a single string with plain spaces. A multi-word query could therefore match across a field boundary — e.g. **"spain es"** matched Spain (name field flowing into the code field), and in the Spanish UI **"espana spain"** matched España (translated-name field flowing into the base-name field). Neither phrase describes any real flag, so both should find nothing.

## Change

`script.js` (`rebuildFlags()`): each field is now normalized separately and the four normalized fields are joined with a NUL character (`String.fromCharCode(0)`) instead of a space:

```js
const searchText = [info.name || '', baseInfo.name || '', code, tags]
    .map(normalizeQueryValue)
    .join(String.fromCharCode(0));
```

The query normalization (`normalizeQueryValue`) strips every character outside `[a-z0-9 ]`, including NUL, so a search term can never contain the sentinel — and therefore can never match across a field boundary. Single-field matching is unchanged, as is the one-`includes()`-per-flag shape of `matchesSearchTerm()`.

## Tests

Two new negative tests in `tests/e2e/app.spec.js`:

- `search cannot match across field boundaries` — "spain es" finds nothing (name/code boundary).
- `Spanish UI search cannot match across the translated and base name` — "espana spain" in the Spanish UI finds nothing (translated/base name boundary).

Full Playwright suite: **60/60 passed** locally (Chromium). Both new tests were also mutation-checked against the old space-joined haystack, where they fail as expected — confirming they actually pin the boundary behavior.

Created with Kimi K3 (Moonshot AI).